### PR TITLE
Add 10-20% performance boost 🚀

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ async function walk(output, prefix, lexer, opts, dirname='', level=0) {
   const rgx = lexer.segments[level];
   const dir = join(opts.cwd, prefix, dirname);
   const files = await readdir(dir);
+  const { dot, filesOnly } = opts;
 
   let i=0, len=files.length, file;
   let fullpath, relpath, stats, isMatch;
@@ -21,7 +22,7 @@ async function walk(output, prefix, lexer, opts, dirname='', level=0) {
   for (; i < len; i++) {
     fullpath = join(dir, file=files[i]);
     relpath = dirname ? join(dirname, file) : file;
-    if (!opts.dot && isHidden.test(relpath)) continue;
+    if (!dot && isHidden.test(relpath)) continue;
     isMatch = lexer.regex.test(relpath);
 
     if ((stats=CACHE[relpath]) === void 0) {
@@ -34,7 +35,7 @@ async function walk(output, prefix, lexer, opts, dirname='', level=0) {
     }
 
     if (rgx && !rgx.test(file)) continue;
-    !opts.filesOnly && isMatch && output.push(join(prefix, relpath));
+    !filesOnly && isMatch && output.push(join(prefix, relpath));
 
     await walk(output, prefix, lexer, opts, relpath, giveup(rgx) ? null : level + 1);
   }


### PR DESCRIPTION
The `dot` and `filesOnly` options are accessed on _every_ loop. Saving them to a variable cuts out the object-key read and uses the reference instead. 

Doing this boosted the average gain over `fast-glob` from `210%` to `230%` for me.

```
glob x 17,943 ops/sec ±0.44% (91 runs sampled)
fast-glob x 30,829 ops/sec ±0.94% (89 runs sampled)
tiny-glob x 102,678 ops/sec ±0.82% (91 runs sampled)
Fastest is tiny-glob
┌───────────┬─────────────────────────┬─────────────┬────────────────┐
│ Name      │ Mean time               │ Ops/sec     │ Diff           │
├───────────┼─────────────────────────┼─────────────┼────────────────┤
│ glob      │ 0.00005573219969436381  │ 17,942.949  │ N/A            │
├───────────┼─────────────────────────┼─────────────┼────────────────┤
│ fast-glob │ 0.0000324372165552068   │ 30,828.786  │ 71.82% faster  │
├───────────┼─────────────────────────┼─────────────┼────────────────┤
│ tiny-glob │ 0.000009739152279806662 │ 102,678.341 │ 233.06% faster │
└───────────┴─────────────────────────┴─────────────┴────────────────┘
```

By the way, this means 233% performance increase compared to `fast-glob` -- meaning, the tagline should be changed to `350%` when comparing to `node-glob` 💪 