### PR TITLE
Add Node 8 engine compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "expansion"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">= 8"
+  },
   "dependencies": {
     "globalyzer": "^0.1.0",
     "globrex": "0.0.2"


### PR DESCRIPTION
Due that you use `async/await` and `promisify` features it's no bad idea to add the engine compatibility to `package.json` 😄