### PR TITLE
Use `cwd` when `isGlob` is false. Fixes #36

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ async function walk(output, prefix, lexer, opts, dirname='', level=0) {
  * @returns {Array} array containing matching files
  */
 module.exports = async function (str, opts={}) {
-  if (str === '') return [];
+  if (!str) return [];
 
   let glob = globalyzer(str);
 

--- a/index.js
+++ b/index.js
@@ -50,13 +50,15 @@ async function walk(output, prefix, lexer, opts, dirname='', level=0) {
  * @returns {Array} array containing matching files
  */
 module.exports = async function (str, opts={}) {
+  if (str === '') return [];
+
   let glob = globalyzer(str);
 
-  if (!glob.isGlob) return fs.existsSync(str) ? [str] : [];
+  opts.cwd = opts.cwd || '.';
+  if (!glob.isGlob) return fs.existsSync(join(opts.cwd, str)) ? [str] : [];
   if (opts.flush) CACHE = {};
 
   let matches = [];
-  opts.cwd = opts.cwd || '.';
   const { path } = globrex(glob.glob, { filepath:true, globstar:true, extended:true });
 
   path.globstar = path.globstar.toString();

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports = async function (str, opts={}) {
   let glob = globalyzer(str);
 
   opts.cwd = opts.cwd || '.';
-  if (!glob.isGlob) return fs.existsSync(join(opts.cwd, str)) ? [str] : [];
+  if (!glob.isGlob) return fs.existsSync(resolve(opts.cwd, str)) ? [str] : [];
   if (opts.flush) CACHE = {};
 
   let matches = [];

--- a/test/glob.js
+++ b/test/glob.js
@@ -106,6 +106,14 @@ test('glob: options.cwd', async t => {
   ]);
 });
 
+test('glob: options.cwd (without glob)', async t => {
+  t.plan(1);
+
+  let dir = join(cwd, 'one', 'child');
+
+  await isMatch(t, '../child/a.js', { cwd:dir }, [ '../child/a.js' ]);
+});
+
 test('glob: options.cwd (absolute)', async t => {
   t.plan(2);
 


### PR DESCRIPTION
Take `opts.cwd` into account when `str` is not a glob.