### PR TITLE
Handle no-glob patterns with absolute option correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,14 @@ module.exports = async function (str, opts={}) {
   let glob = globalyzer(str);
 
   opts.cwd = opts.cwd || '.';
-  if (!glob.isGlob) return fs.existsSync(resolve(opts.cwd, str)) ? [str] : [];
+
+  if (!glob.isGlob) {
+    let resolved = resolve(opts.cwd, str);
+    if (!fs.existsSync(resolved)) return []
+
+    return opts.absolute ? [resolved] : [str];
+  }
+
   if (opts.flush) CACHE = {};
 
   let matches = [];

--- a/test/glob.js
+++ b/test/glob.js
@@ -169,6 +169,16 @@ test('glob: options.absolute', async t => {
   ]);
 });
 
+test('glob: options.absolute (without glob)', async t => {
+  t.plan(1);
+
+  let dir = join(cwd, 'one', 'child');
+
+  await isMatch(t, '../child/a.js', { cwd:dir, absolute:true }, [
+    resolve(dir, '../child/a.js')
+  ]);
+});
+
 test('glob: options.filesOnly', async t => {
   t.plan(2);
 


### PR DESCRIPTION
Patterns without globs ignore the absolute option.