### PR TITLE
WIP: Fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,6 @@ module.exports = async function (str, opts={}) {
   if (!str) return [];
 
   let glob = globalyzer(str);
-
   opts.cwd = resolve(opts.cwd || '.');
 
   if (!glob.isGlob) {
@@ -69,9 +68,8 @@ module.exports = async function (str, opts={}) {
     }
   }
 
-  if (opts.flush) CACHE = {};
-
   let matches = [];
+  if (opts.flush) CACHE = {};
   const { path } = globrex(glob.glob, { filepath:true, globstar:true, extended:true });
 
   path.globstar = path.globstar.toString();

--- a/index.js
+++ b/index.js
@@ -55,18 +55,16 @@ module.exports = async function (str, opts={}) {
 
   let glob = globalyzer(str);
 
-  opts.cwd = opts.cwd || '.';
+  opts.cwd = resolve(opts.cwd || '.');
 
   if (!glob.isGlob) {
     try {
-      let resolved = resolve(opts.cwd, str);
+      let resolved = join(opts.cwd, str);
       let dirent = await stat(resolved);
       if (opts.filesOnly && !dirent.isFile()) return [];
-
       return opts.absolute ? [resolved] : [str];
     } catch (err) {
       if (err.code != 'ENOENT') throw err;
-
       return [];
     }
   }
@@ -79,5 +77,5 @@ module.exports = async function (str, opts={}) {
   path.globstar = path.globstar.toString();
   await walk(matches, glob.base, path, opts, '.', 0);
 
-  return opts.absolute ? matches.map(x => resolve(opts.cwd, x)) : matches;
+  return opts.absolute ? matches.map(x => join(opts.cwd, x)) : matches;
 };

--- a/sync.js
+++ b/sync.js
@@ -52,30 +52,26 @@ module.exports = function (str, opts={}) {
   if (!str) return [];
 
   let glob = globalyzer(str);
-
-  opts.cwd = opts.cwd || '.';
+  opts.cwd = resolve(opts.cwd || '.');
 
   if (!glob.isGlob) {
     try {
-      let resolved = resolve(opts.cwd, str);
+      let resolved = join(opts.cwd, str);
       let dirent = fs.statSync(resolved);
       if (opts.filesOnly && !dirent.isFile()) return []
-
       return opts.absolute ? [resolved] : [str];
     } catch (err) {
       if (err.code != 'ENOENT') throw err;
-
       return [];
     }
   }
 
-  if (opts.flush) CACHE = {};
-
   let matches = [];
+  if (opts.flush) CACHE = {};
   const { path } = globrex(glob.glob, { filepath:true, globstar:true, extended:true });
 
   path.globstar = path.globstar.toString();
   walk(matches, glob.base, path, opts, '.', 0);
 
-  return opts.absolute ? matches.map(x => resolve(opts.cwd, x)) : matches;
+  return opts.absolute ? matches.map(x => join(opts.cwd, x)) : matches;
 };

--- a/test/glob.js
+++ b/test/glob.js
@@ -19,7 +19,7 @@ test('glob: standard', async t => {
 });
 
 test('glob: glob', async t => {
-  t.plan(14);
+  t.plan(15);
 
   t.same(await glob(''), []);
   t.same(await glob('.'), ['.']);
@@ -32,6 +32,12 @@ test('glob: glob', async t => {
     'test/fixtures',
     'test/glob.js',
     'test/helpers'
+  ]);
+
+  await isMatch(t, '*', { cwd: __dirname }, [
+    'fixtures',
+    'glob.js',
+    'helpers'
   ]);
 
   await isMatch(t, 'test/fixtures/*', {}, [


### PR DESCRIPTION
Resolves the `opts.cwd` once & only once. Every other contact point will use `path.join` instead.

Depends on https://github.com/terkelg/globalyzer/pull/2 to pass tests. That's where the problems actually lived.