### PR TITLE
Add missing semicolon

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -59,7 +59,7 @@ module.exports = function (str, opts={}) {
     try {
       let resolved = resolve(opts.cwd, str);
       let dirent = fs.statSync(resolved);
-      if (opts.filesOnly && !dirent.isFile()) return []
+      if (opts.filesOnly && !dirent.isFile()) return [];
 
       return opts.absolute ? [resolved] : [str];
     } catch (err) {


### PR DESCRIPTION
All the other lines have semicolons as does `index.js` on the line corresponding to this one