### PR TITLE
break: require Node 12.x minimum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nodejs: [8, 10, 12, 14]
+        nodejs: [12, 14, 16]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     },
     "./package.json": "./package.json"
   },
+  "engines": {
+    "node": ">=12"
+  },
   "scripts": {
     "build": "bundt",
     "bench": "node bench",


### PR DESCRIPTION
Technically, stable `tiny-glob` _implicitly_ requires Node 8.x because of its `async` usage. The `tiny-glob/sync` module only requires Node 6.x

This PR should serve as a reminder that we have to remember/decide what to do here. There's nothing _preventing_ `tiny-glob` from remaining at 6.x support (for `sync`), but this will be determined by @terkelg's runtime code changes for the 1.0 

---

_Opening as a draft PR because it's a reminder~_