### PR TITLE
break: use named exports

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,4 @@ type Options = {
 
 type FilePath = string;
 
-declare function glob(str: string, opts?: Options): Promise<FilePath[]>;
-
-export = glob;
+export function glob(str: string, opts?: Options): Promise<FilePath[]>;

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ async function walk(output, prefix, lexer, opts, dirname='', level=0) {
  * @param {Boolean} [options.flush=false] Reset cache object
  * @returns {Array} array containing matching files
  */
-export default async function (str, opts={}) {
+export async function glob(str, opts={}) {
   if (!str) return [];
 
   let glob = globalyzer(str);

--- a/src/sync.d.ts
+++ b/src/sync.d.ts
@@ -8,6 +8,4 @@ type Options = {
 
 type FilePath = string;
 
-declare function glob(str: string, opts?: Options): FilePath[];
-
-export = glob;
+export function glob(str: string, opts?: Options): FilePath[];

--- a/src/sync.js
+++ b/src/sync.js
@@ -49,7 +49,7 @@ function walk(output, prefix, lexer, opts, dirname='', level=0) {
  * @param {Boolean} [options.flush=false] Reset cache object
  * @returns {Array} array containing matching files
  */
-export default function (str, opts={}) {
+export function glob(str, opts={}) {
   if (!str) return [];
 
   let glob = globalyzer(str);

--- a/test/glob.js
+++ b/test/glob.js
@@ -1,7 +1,7 @@
 const test = require('tape');
 const { join, resolve } = require('path');
 const { order, unixify } = require('./helpers');
-const glob = require('../dist');
+const { glob } = require('../dist');
 
 const cwd = join(__dirname, 'fixtures');
 


### PR DESCRIPTION
This is a "might as well" for the next major anyway. 
The main motivation is for TypeScript definitions and/or Intellisense.

Without this change, and with the current definitions, then both modules will always throw a type error (or lack a signature) when using `import` statements.

If the definitions changed to be ESM-compliant, then `require` usage for CommonJS would throw type error (or lack a signature).

Named exports make all variants work in harmony