### PR TITLE
Fix bug relating to use of relative paths in CACHE

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,8 @@ async function walk(output, prefix, lexer, opts, dirname='', level=0) {
     if (!dot && isHidden.test(relpath)) continue;
     isMatch = lexer.regex.test(relpath);
 
-    if ((stats=CACHE[relpath]) === void 0) {
-      CACHE[relpath] = stats = fs.lstatSync(fullpath);
+    if ((stats=CACHE[fullpath]) === void 0) {
+      CACHE[fullpath] = stats = fs.lstatSync(fullpath);
     }
 
     if (!stats.isDirectory()) {

--- a/test/glob.js
+++ b/test/glob.js
@@ -228,3 +228,21 @@ test('glob: deep match with higher level siblings', async t => {
     'test/fixtures/deep/b/c/d'
   ]);
 });
+
+test('glob: cache is keyed by absolute path', async (t) => {
+  t.plan(2);
+
+  // "one/child" is a directory.
+  await isMatch(t, 'test/fixtures/one/**/*.txt', {}, [
+    'test/fixtures/one/a.txt',
+    'test/fixtures/one/b.txt',
+    'test/fixtures/one/child/a.txt',
+  ]);
+
+  // "two/child" is a file. If we re-use cached stats from "one/child" here,
+  // then we will mistakenly try to descend into "child" as a directory, even
+  // though it is a file, raising an error.
+  await isMatch(t, 'test/fixtures/two/**/*.txt', {}, [
+    'test/fixtures/two/a.txt',
+  ]);
+});


### PR DESCRIPTION
The `CACHE` object is used to remember whether a path was a directory or not across `glob()` calls. Previously, this cache was keyed by the relative path of the file (i.e. the basename).

This can result in missing results (not descending into a directory because it was incorrectly thought to be a file), or an exception (attempting to descend into a file because it was thought to be a directory).

Now, the `CACHE` object is instead keyed by the full path, instead of the relative path.